### PR TITLE
Adição de novos indicadores

### DIFF
--- a/app.py
+++ b/app.py
@@ -47,6 +47,9 @@ indicator_names = {
     'selic': 'Taxa SELIC Diária',
     'selic_meta': 'Meta da Taxa SELIC',
     'transacoes': 'Saldo em Transações Correntes',
+    'cambio_dolar': 'Taxa de Câmbio do Dólar Diária',
+    'igpm': 'Índice geral de preços do mercado (IGP-M)',
+    'inpc': 'Índice nacional de preços ao consumidor (INPC)',
     'resultado_primario': 'Resultado Primário'
 }
 

--- a/data_collector.py
+++ b/data_collector.py
@@ -17,6 +17,9 @@ class BCBDataCollector:
             'selic': 11,          # Taxa SELIC diária
             'selic_meta': 4189,   # Meta da taxa SELIC
             'transacoes': 22707,  # Balanço de Pagamentos: Saldo em Transações Correntes
+            'cambio_dolar': 1,    # Taxa de Câmbio - Dólar (Diário)
+            'igpm': 189,          #	Índice geral de preços do mercado (IGP-M)
+            'inpc': 188,          # Índice nacional de preços ao consumidor (INPC)
             'resultado_primario': 7547  # Indicadores Fiscais: Resultado Primário
         }
     

--- a/database_manager.py
+++ b/database_manager.py
@@ -29,6 +29,9 @@ class DatabaseManager:
             'selic',            # Taxa SELIC diária
             'selic_meta',       # Meta da taxa SELIC
             'transacoes',       # Balanço de Pagamentos: Saldo em Transações Correntes
+            'cambio_dolar',     # Taxa de Câmbio - Dólar (Diário)
+            'igpm',             # Índice geral de preços do mercado (IGP-M)
+            'inpc',             # Índice nacional de preços ao consumidor (INPC)
             'resultado_primario' # Indicadores Fiscais: Resultado Primário
         ]
         

--- a/main.py
+++ b/main.py
@@ -103,6 +103,9 @@ def dashboard_page():
         'selic': 'Taxa SELIC Diária',
         'selic_meta': 'Meta da Taxa SELIC',
         'transacoes': 'Saldo em Transações Correntes',
+        'cambio_dolar': 'Taxa de Câmbio do Dólar Diária',
+        'igpm': 'Índice geral de preços do mercado (IGP-M)',
+        'inpc': 'Índice nacional de preços ao consumidor (INPC)',
         'resultado_primario': 'Resultado Primário'
     }
     
@@ -187,6 +190,9 @@ def ml_page():
         'selic': 'Taxa SELIC Diária',
         'selic_meta': 'Meta da Taxa SELIC',
         'transacoes': 'Saldo em Transações Correntes',
+        'cambio_dolar': 'Taxa de Câmbio do Dólar Diária',
+        'igpm': 'Índice geral de preços do mercado (IGP-M)',
+        'inpc': 'Índice nacional de preços ao consumidor (INPC)',
         'resultado_primario': 'Resultado Primário'
     }
     

--- a/ml_app.py
+++ b/ml_app.py
@@ -31,6 +31,9 @@ indicator_names = {
     'selic': 'Taxa SELIC Diária',
     'selic_meta': 'Meta da Taxa SELIC',
     'transacoes': 'Saldo em Transações Correntes',
+    'cambio_dolar': 'Taxa de Câmbio do Dólar Diária',
+    'igpm': 'Índice geral de preços do mercado (IGP-M)',
+    'inpc': 'Índice nacional de preços ao consumidor (INPC)',
     'resultado_primario': 'Resultado Primário'
 }
 


### PR DESCRIPTION
Trabalho da sprint de 28/04 - 05/05.

Adicionado 3 novos indicadores presentes na atividade 01 da sprint de 07/04 - 14/04:
- Taxa de Câmbio do Dólar Diária;
- Índice geral de preços do mercado (IGP-M);
- Índice nacional de preços ao consumidor (INPC).

O ultimo valor faltando é a taxa de desemprego, que não consegui encontrar valores ativos e atualizados na API utilizada.