### PR TITLE
Feat/reorganizar tabelas dashboard

### DIFF
--- a/app_pages/Dashboard_Economico.py
+++ b/app_pages/Dashboard_Economico.py
@@ -1,5 +1,6 @@
 import streamlit as st
 import plotly.express as px
+import pandas as pd
 from components.indicadores import indicator_names, load_data
 
 def dashboard_page():
@@ -27,6 +28,12 @@ def dashboard_page():
     else:
         for indicator in indicators:
             data = load_data(indicator)
+
+            if data is not None and not data.empty:
+                # Garante que as colunas de data sejam do tipo datetime
+                data['date'] = pd.to_datetime(data['date'])
+                data['created_at'] = pd.to_datetime(data['created_at'])
+
             if data is not None and not data.empty:
                 st.subheader(indicator_names[indicator])
                 fig = px.line(
@@ -36,13 +43,40 @@ def dashboard_page():
                 )
                 st.plotly_chart(fig, use_container_width=True)
 
-                 # Adicione este bloco:
-                col1, col2 = st.columns(2)
-                with col1:
-                    st.write("Estatísticas")
-                    st.dataframe(data['value'].describe())
-                with col2:
-                    st.write("Dados Recentes")
-                    st.dataframe(data.sort_values('date', ascending=False).head(5))
+                st.markdown("---")
+
+                # Tabela 1: Estatísticas Principais
+                st.markdown("##### Estatísticas")
+                all_stats = data['value'].describe()
+                desired_metrics_map = {
+                    'mean': 'Média',
+                    '50%': 'Mediana',
+                    'std': 'Desvio Padrão',
+                    'min': 'Mínimo',
+                    'max': 'Máximo'
+                }
+                selected_stats = all_stats.loc[desired_metrics_map.keys()]
+                final_stats_df = selected_stats.to_frame(name='Valor').rename(index=desired_metrics_map)
+                st.table(final_stats_df)
+
+                st.write("") 
+
+                # Tabela 2: Dados Recentes (com todas as colunas e formatação)
+                st.markdown("##### Dados Recentes")
+                recent_data = data.sort_values('date', ascending=False).head(5).copy()
+                
+                recent_data['date'] = recent_data['date'].dt.strftime('%d/%m/%Y')
+                recent_data['created_at'] = recent_data['created_at'].dt.tz_localize('UTC').dt.tz_convert('America/Sao_Paulo').dt.strftime('%d/%m/%Y %H:%M')
+
+                recent_data.rename(columns={
+                    'id': 'ID',
+                    'date': 'Data do Valor',
+                    'value': 'Valor',
+                    'created_at': 'Data de Coleta'
+                }, inplace=True)
+                
+                st.table(recent_data[['ID', 'Data do Valor', 'Valor', 'Data de Coleta']].reset_index(drop=True))
+                
+
             else:
                 st.error(f"Não há dados disponíveis para {indicator_names[indicator]}.")

--- a/app_pages/Dashboard_Economico.py
+++ b/app_pages/Dashboard_Economico.py
@@ -69,13 +69,12 @@ def dashboard_page():
                 recent_data['created_at'] = recent_data['created_at'].dt.tz_localize('UTC').dt.tz_convert('America/Sao_Paulo').dt.strftime('%d/%m/%Y %H:%M')
 
                 recent_data.rename(columns={
-                    'id': 'ID',
                     'date': 'Data do Valor',
                     'value': 'Valor',
                     'created_at': 'Data de Coleta'
                 }, inplace=True)
                 
-                st.table(recent_data[['ID', 'Data do Valor', 'Valor', 'Data de Coleta']].reset_index(drop=True))
+                st.table(recent_data[[ 'Data do Valor', 'Valor', 'Data de Coleta']].reset_index(drop=True))
                 
 
             else:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def install_requirements():
         "prophet",
         "fpdf2",
         "cmdstanpy",
-        "kaleido"
+        "kaleidogit"
     ]
     for package in packages:
         subprocess.check_call([sys.executable, "-m", "pip", "install", package])


### PR DESCRIPTION
### Resumo das Alterações:
* **Modificado** o arquivo `app_pages/Dashboard_Economico.py` para alterar a exibição das tabelas de dados.
* A tabela de "Estatísticas" foi padronizada para exibir apenas as 5 métricas principais (Média, Mediana, etc.) em formato transposto, alinhando-se com a página de Previsões.
* A tabela de "Dados Recentes" foi mantida, mas teve os cabeçalhos das colunas renomeados e as colunas de data formatadas para melhor legibilidade.
* A conversão de fuso horário (UTC para Brasília) foi aplicada na coluna "Data de Coleta".
* O layout foi alterado para vertical (uma tabela embaixo da outra).

### Propósito da Alteração:
Esta PR padroniza a apresentação de dados na página "Dashboard Econômico", fazendo com que o estilo das tabelas seja consistente com o da página "Previsões com ML". Isso melhora a experiência do usuário (UX), a legibilidade e a precisão das informações (fuso horário).

### Como Testar / Reproduzir:
1. Puxe este ramo: `git pull origin feat/padroniza-tabelas-dashboard`
2. Inicie a aplicação: `streamlit run main.py`
3. Navegue para a página **"Dashboard Econômico"**.
4. Selecione um ou mais indicadores.
5. Verifique se, para cada indicador, as tabelas de "Estatísticas Principais" e "Dados Mais Recentes" aparecem corretamente formatadas e uma embaixo da outra.

### Pontos de Atenção para o Revisor:
* Verificar se a nova formatação das tabelas é consistente com o design da página de Previsões.
* Confirmar se a conversão de fuso horário na coluna "Data de Coleta" está exibindo a hora local (Brasília) corretamente.

### Checklist do Desenvolvedor:
- [x] O código foi testado localmente e está funcionando conforme o esperado?
- [x] Todos os comentários e código legado desnecessário foram removidos?
- [ ] O README (ou outra documentação) foi atualizado, se necessário? *(não foi necessário)*
- [ ] Todas as dependências externas foram listadas no `setup.py` (se houver novas)? *(não houve novas)*